### PR TITLE
Disable colorizing the output if stdout isn't a terminal.

### DIFF
--- a/src/inc/coloshell.hpp
+++ b/src/inc/coloshell.hpp
@@ -27,6 +27,9 @@
 
 #ifdef WINDOWS
 #include <windows.h>
+#include <fileapi.h>
+#else
+#include <unistd.h>
 #endif
 
 #define COLORS_ENABLED                     // remove this define if you don't want color in your shell
@@ -53,6 +56,17 @@
 
 #endif
 
+ /**
+ * \def should_emit_color(void)
+ * Return whether or not the caller should enable colorized output. For
+ * example, if stdout is redirected to a file then the output won't be colored.
+ */
+#ifdef WINDOWS
+#define should_emit_color() (GetFileType(GetStdHandle(STD_OUTPUT_HANDLE)) == FILE_TYPE_CHAR)
+#else
+#define should_emit_color() (isatty(STDOUT_FILENO))
+#endif
+
 /**
  * \fn static void enable_color(const Colors colo)
  * \brief Enable a color in your shell
@@ -62,6 +76,9 @@
 static void enable_color(const Colors colo)
 {
 #ifdef COLORS_ENABLED
+    if (!should_emit_color())
+        return;
+
 #ifdef WINDOWS
     HANDLE hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
     if(hStdOutput == INVALID_HANDLE_VALUE)
@@ -90,6 +107,9 @@ static void enable_color(const Colors colo)
 static void disable_color(void)
 {
 #ifdef COLORS_ENABLED
+    if (!should_emit_color())
+        return;
+
 #ifdef WINDOWS
     HANDLE hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
     if(hStdOutput == INVALID_HANDLE_VALUE)


### PR DESCRIPTION
Here's the other diff. I was able to test this on a Linux machine and it worked as expected.