### PR TITLE
Add print-bytes option

### DIFF
--- a/src/rp/arm.hpp
+++ b/src/rp/arm.hpp
@@ -43,7 +43,6 @@ public:
     instr.virtual_address_in_memory = uintptr_t(vaddr);
     instr.disassembly = mnemonic + ' ' + std::string(insn[0].op_str);
     instr.size = insn[0].size;
-    instr.bytes.insert(instr.bytes.begin(), data, data + instr.size);
 
     instr.cap_is_branch = false;
     instr.cap_is_valid_ending_instr = false;

--- a/src/rp/arm64.hpp
+++ b/src/rp/arm64.hpp
@@ -37,7 +37,6 @@ public:
     instr.virtual_address_in_memory = uintptr_t(vaddr);
     instr.disassembly = mnemonic + ' ' + std::string(insn[0].op_str);
     instr.size = insn[0].size;
-    instr.bytes.insert(instr.bytes.begin(), data, data + instr.size);
 
     instr.cap_is_branch = false;
     instr.cap_is_valid_ending_instr = false;

--- a/src/rp/coloshell.hpp
+++ b/src/rp/coloshell.hpp
@@ -261,8 +261,9 @@ template <class T> static void coloshell(const T t, const Colors colo) {
       disable_color();                                                         \
       fmt::print(": ");                                                        \
       enable_color(COLO_GREEN);                                                \
-      (gadget).display_disassembly();                                          \
+      (gadget).print_disassembly();                                            \
       if (g_opts.print_bytes) {                                                \
+        fmt::print(" ");                                                       \
         (gadget).print_bytes();                                                \
       }                                                                        \
       fmt::print(" ({} found)\n", (gadget).get_nb());                          \

--- a/src/rp/coloshell.hpp
+++ b/src/rp/coloshell.hpp
@@ -262,7 +262,9 @@ template <class T> static void coloshell(const T t, const Colors colo) {
       fmt::print(": ");                                                        \
       enable_color(COLO_GREEN);                                                \
       (gadget).display_disassembly();                                          \
-      (gadget).print_bytes();                                                  \
+      if (g_opts.print_bytes) {                                                \
+        (gadget).print_bytes();                                                \
+      }                                                                        \
       fmt::print(" ({} found)\n", (gadget).get_nb());                          \
       disable_color();                                                         \
     } else {                                                                   \

--- a/src/rp/gadget.hpp
+++ b/src/rp/gadget.hpp
@@ -44,9 +44,12 @@ public:
     return disassembly;
   }
 
-  void display_disassembly() const {
-    for (const auto &i : m_instructions) {
-      fmt::print("{} ; ", i.get_disassembly());
+  void print_disassembly() const {
+    for (size_t idx = 0; idx < m_instructions.size(); idx++) {
+      fmt::print("{} ;", m_instructions[idx].get_disassembly());
+      if ((idx + 1) < m_instructions.size()) {
+        fmt::print(" ");
+      }
     }
   }
 

--- a/src/rp/intelbeaengine.hpp
+++ b/src/rp/intelbeaengine.hpp
@@ -44,7 +44,6 @@ public:
     instr.disassembly = m_disasm.CompleteInstr;
     instr.mnemonic = m_disasm.Instruction.Mnemonic;
     instr.size = len_instr;
-    instr.bytes.insert(instr.bytes.begin(), data, data + instr.size);
     instr.bea_branch_type = m_disasm.Instruction.BranchType;
     instr.bea_addr_value = m_disasm.Instruction.AddrValue;
     return instr;

--- a/src/rp/main.cpp
+++ b/src/rp/main.cpp
@@ -59,6 +59,7 @@ int main(int argc, char *argv[]) {
               "don't use the image base of the binary, but yours instead");
   rp.add_flag("--allow-branches", g_opts.allow_branches,
               "allow branches in a gadget");
+  rp.add_flag("--print-bytes", g_opts.print_bytes, "print the gadget bytes");
 
   CLI11_PARSE(rp, argc, argv);
 

--- a/src/rp/options.hpp
+++ b/src/rp/options.hpp
@@ -18,6 +18,7 @@ struct Options_t {
   bool unique = false;
   bool version = false;
   bool thumb = false;
+  bool print_bytes = false;
 };
 
 extern Options_t g_opts;

--- a/src/rp/ropsearch_algorithm.cpp
+++ b/src/rp/ropsearch_algorithm.cpp
@@ -54,6 +54,11 @@ void find_all_gadget_from_ret(const std::vector<uint8_t> &memory,
         break;
       }
 
+      // Grab the bytes if we'll need to print them later
+      if (g_opts.print_bytes) {
+        instr.bytes.assign(data, data + instr.size);
+      }
+
       // Sets the begining address of the gadget as soon as we find the first
       // one
       if (list_of_instr.size() == 0) {

--- a/src/rp/ropsearch_algorithm.cpp
+++ b/src/rp/ropsearch_algorithm.cpp
@@ -56,7 +56,7 @@ void find_all_gadget_from_ret(const std::vector<uint8_t> &memory,
 
       // Grab the bytes if we'll need to print them later
       if (g_opts.print_bytes) {
-        instr.bytes.assign(data, data + instr.size);
+        instr.bytes.assign(EIP_, EIP_ + instr.size);
       }
 
       // Sets the begining address of the gadget as soon as we find the first

--- a/src/rp/ropsearch_algorithm.cpp
+++ b/src/rp/ropsearch_algorithm.cpp
@@ -132,7 +132,7 @@ void find_rop_gadgets(const std::vector<uint8_t> &section, const uint64_t vaddr,
 
     // Grab the bytes if we'll need to print them later
     if (g_opts.print_bytes) {
-      ret_instr.bytes.assign(data, data + ret_instr.size);
+      ret_instr.bytes.assign(data + offset, data + offset + ret_instr.size);
     }
 
     // Do not forget to add the ending instruction only -- we give to the user

--- a/src/rp/ropsearch_algorithm.cpp
+++ b/src/rp/ropsearch_algorithm.cpp
@@ -116,7 +116,7 @@ void find_rop_gadgets(const std::vector<uint8_t> &section, const uint64_t vaddr,
   const uint32_t alignement = disass_engine.get_alignement();
   for (uint64_t offset = 0; offset < size; offset += alignement) {
     DisassEngineReturn ret;
-    InstructionInformation instr = disass_engine.disass(
+    InstructionInformation ret_instr = disass_engine.disass(
         data + offset, size - offset, SafeIntAdd(vaddr, offset), ret);
 
     // OK either this is an unknow opcode & we goto the next one Or the
@@ -126,12 +126,14 @@ void find_rop_gadgets(const std::vector<uint8_t> &section, const uint64_t vaddr,
       continue;
     }
 
-    if (!disass_engine.is_valid_ending_instruction(instr)) {
+    if (!disass_engine.is_valid_ending_instruction(ret_instr)) {
       continue;
     }
 
-    // Okay I found a RET ; now I can build the gadget
-    InstructionInformation ret_instr(instr);
+    // Grab the bytes if we'll need to print them later
+    if (g_opts.print_bytes) {
+      ret_instr.bytes.assign(data, data + ret_instr.size);
+    }
 
     // Do not forget to add the ending instruction only -- we give to the user
     // all gadget with < depth instruction


### PR DESCRIPTION
This PR adds `--print-bytes` option which prints the gadgets' bytes if turned on (fixes #36).