### PR TITLE
Decluter `InstructionInformation`

### DIFF
--- a/src/rp/arm.hpp
+++ b/src/rp/arm.hpp
@@ -43,9 +43,6 @@ public:
     instr.virtual_address_in_memory = uintptr_t(vaddr);
     instr.disassembly = mnemonic + ' ' + std::string(insn[0].op_str);
     instr.size = insn[0].size;
-
-    instr.cap_is_branch = false;
-    instr.cap_is_valid_ending_instr = false;
     ret = AllRight;
 
     if (insn[0].detail == nullptr) {
@@ -54,28 +51,28 @@ public:
     }
 
     if (cs_insn_group(m_handle, insn, ARM_GRP_JUMP)) {
-      instr.cap_is_branch = true;
-      instr.cap_is_valid_ending_instr =
+      instr.is_branch = true;
+      instr.is_valid_ending_instr =
           insn[0].detail->arm.op_count == 1 &&
           insn[0].detail->arm.operands[0].type != ARM_OP_IMM;
     } else if (mnemonic == "b" || mnemonic == "bl" || mnemonic == "blx" ||
                mnemonic == "cb" || mnemonic == "cbz") {
-      instr.cap_is_branch = true;
+      instr.is_branch = true;
     } else if (mnemonic == "swi" || mnemonic == "svc") {
-      instr.cap_is_branch = true;
-      instr.cap_is_valid_ending_instr = true;
+      instr.is_branch = true;
+      instr.is_valid_ending_instr = true;
     } else if (mnemonic == "mov" && insn[0].detail->arm.op_count >= 1 &&
                insn[0].detail->arm.operands[0].type == ARM_OP_REG &&
                insn[0].detail->arm.operands[0].reg == ARM_REG_PC) {
-      instr.cap_is_branch = true;
-      instr.cap_is_valid_ending_instr = true;
+      instr.is_branch = true;
+      instr.is_valid_ending_instr = true;
     } else if (mnemonic == "bx") {
-      instr.cap_is_branch = true;
-      instr.cap_is_valid_ending_instr =
+      instr.is_branch = true;
+      instr.is_valid_ending_instr =
           insn[0].detail->arm.operands[0].type == ARM_OP_REG;
     } else if (mnemonic == "blx") {
-      instr.cap_is_branch = true;
-      instr.cap_is_valid_ending_instr = true;
+      instr.is_branch = true;
+      instr.is_valid_ending_instr = true;
     } else if (mnemonic == "pop") {
       bool has_pc = false;
       for (size_t i = 0; i < insn[0].detail->arm.op_count; ++i) {
@@ -87,23 +84,13 @@ public:
       }
 
       if (has_pc) {
-        instr.cap_is_branch = true;
-        instr.cap_is_valid_ending_instr = true;
+        instr.is_branch = true;
+        instr.is_valid_ending_instr = true;
       }
     }
 
     cs_free(insn, count);
     return instr;
-  }
-
-  bool is_valid_ending_instruction(
-      const InstructionInformation &instr) const override {
-    return instr.cap_is_valid_ending_instr;
-  }
-
-  bool
-  is_valid_instruction(const InstructionInformation &instr) const override {
-    return instr.cap_is_branch == false;
   }
 
   uint32_t get_size_biggest_instruction() const override { return 4; }

--- a/src/rp/arm64.hpp
+++ b/src/rp/arm64.hpp
@@ -37,9 +37,6 @@ public:
     instr.virtual_address_in_memory = uintptr_t(vaddr);
     instr.disassembly = mnemonic + ' ' + std::string(insn[0].op_str);
     instr.size = insn[0].size;
-
-    instr.cap_is_branch = false;
-    instr.cap_is_valid_ending_instr = false;
     ret = AllRight;
 
     if (insn[0].detail == nullptr) {
@@ -51,24 +48,14 @@ public:
     const bool Call = cs_insn_group(m_handle, insn, ARM64_GRP_CALL);
     const bool Ret = cs_insn_group(m_handle, insn, ARM64_GRP_RET);
     const bool Int = cs_insn_group(m_handle, insn, ARM64_GRP_INT);
-    instr.cap_is_branch = Jump || Call || Ret || Int;
-    instr.cap_is_valid_ending_instr =
+    instr.is_branch = Jump || Call || Ret || Int;
+    instr.is_valid_ending_instr =
         Ret || Int ||
         ((Jump || Call) && insn[0].detail->arm64.op_count == 1 &&
          insn[0].detail->arm64.operands[0].type != ARM64_OP_IMM);
 
     cs_free(insn, count);
     return instr;
-  }
-
-  bool is_valid_ending_instruction(
-      const InstructionInformation &instr) const override {
-    return instr.cap_is_valid_ending_instr;
-  }
-
-  bool
-  is_valid_instruction(const InstructionInformation &instr) const override {
-    return instr.cap_is_branch == false;
   }
 
   uint32_t get_size_biggest_instruction() const override { return 4; }

--- a/src/rp/disassenginewrapper.hpp
+++ b/src/rp/disassenginewrapper.hpp
@@ -6,7 +6,6 @@
 #include <vector>
 
 struct InstructionInformation {
-  // Generic fields
   std::string disassembly;
   std::string mnemonic;
   uint32_t size = 0;

--- a/src/rp/disassenginewrapper.hpp
+++ b/src/rp/disassenginewrapper.hpp
@@ -13,15 +13,8 @@ struct InstructionInformation {
   uintptr_t address = 0;
   uintptr_t virtual_address_in_memory = 0;
   std::vector<uint8_t> bytes;
-
-  // Capstone field
-  bool cap_is_branch = false;
-  bool cap_is_valid_ending_instr = false;
-
-  // BeaEngine fields
-  uint32_t bea_branch_type = 0; // This is used by BeaEngine ; and this will
-                                // hold DISASM.Instruction.BranchType
-  uint64_t bea_addr_value = 0;  // This is used by BeaEngine, DISASM.Instruction
+  bool is_branch = false;
+  bool is_valid_ending_instr = false;
 };
 
 enum DisassEngineReturn { UnknownInstruction, OutOfBlock, AllRight };
@@ -39,10 +32,6 @@ public:
   virtual InstructionInformation disass(const uint8_t *data, uint64_t len,
                                         const uint64_t vaddr,
                                         DisassEngineReturn &ret) = 0;
-  virtual bool
-  is_valid_ending_instruction(const InstructionInformation &instr) const = 0;
-  virtual bool
-  is_valid_instruction(const InstructionInformation &instr) const = 0;
   virtual uint32_t get_size_biggest_instruction() const = 0;
   virtual uint32_t get_alignement() const = 0;
 };

--- a/src/rp/gadget.hpp
+++ b/src/rp/gadget.hpp
@@ -142,34 +142,18 @@ public:
           return true;
         }
 
-        const auto &current_a_bytes = a.m_instructions[current_a_idx].bytes();
-        const size_t current_a_bytes_size = current_a_bytes.size();
-        const auto &current_b_bytes = b.m_instructions[current_b_idx].bytes();
-        const size_t current_b_bytes_size = current_b_bytes.size();
-        while (1) {
-          if (current_a_bytes_idx >= current_a_bytes_size) {
-            current_a_idx++;
-            current_a_bytes_idx = 0;
-            break;
-          }
-
-          if (current_b_bytes_idx >= current_b_bytes_size) {
-            current_b_idx++;
-            current_b_bytes_idx = 0;
-            break;
-          }
-
-          if (current_a_bytes[current_a_bytes_idx] !=
-              current_b_bytes[current_b_bytes_idx]) {
-            return current_a_bytes[current_a_bytes_idx] <
-                   current_b_bytes[current_b_bytes_idx];
-          }
-
-          current_a_bytes_idx++;
-          current_b_bytes_idx++;
+        const auto &current_a_disass =
+            a.m_instructions[current_a_idx].get_disassembly();
+        const auto &current_b_disass =
+            b.m_instructions[current_b_idx].get_disassembly();
+        const int compare = current_a_disass.compare(current_b_disass);
+        if (compare != 0) {
+          return (compare < 0) ? true : false;
         }
+
+        current_a_idx++;
+        current_b_idx++;
       }
-      return false;
     }
   };
 
@@ -186,8 +170,8 @@ private:
   uint32_t m_size; /*!< the size in byte of the gadget*/
 
   std::vector<Instruction>
-      m_instructions; /*!< the list of the different instructions composing the
-                         gadget*/
+      m_instructions; /*!< the list of the different instructions composing
+                         the gadget*/
 
   mutable std::vector<Info>
       m_info_gadgets; /*!< the vector which stores where you can find the same

--- a/src/rp/intelbeaengine.hpp
+++ b/src/rp/intelbeaengine.hpp
@@ -48,7 +48,10 @@ public:
     const auto branch_type = m_disasm.Instruction.BranchType;
     const auto addr_value = m_disasm.Instruction.AddrValue;
     const char *mnemonic_s = m_disasm.Instruction.Mnemonic;
-    const char *disass_s = m_disasm.CompleteInstr;
+    const char *disass_s = instr.disassembly.c_str();
+
+    instr.is_branch = branch_type != 0;
+
     const bool is_good_branch_type =
         // We accept all the ret type instructions (except retf/iret)
         (branch_type == RetType && (strncmp(mnemonic_s, "retf", 4) != 0) &&
@@ -63,14 +66,9 @@ public:
          (strncmp(disass_s, "syscall", 7) == 0));
 
     instr.is_valid_ending_instr =
-        !(is_good_branch_type &&
-          // Yeah, we don't accept jmp far/call far
-          instr.disassembly.find("far") == std::string::npos);
-
-    instr.is_branch = !(branch_type != RetType && branch_type != JmpType &&
-                        ((branch_type == CallType && addr_value == 0) ||
-                         branch_type != CallType) &&
-                        instr.disassembly.find("far") == std::string::npos);
+        is_good_branch_type &&
+        // Yeah, we don't accept jmp far/call far
+        instr.disassembly.find("far") == std::string::npos;
 
     return instr;
   }

--- a/src/rp/ropsearch_algorithm.cpp
+++ b/src/rp/ropsearch_algorithm.cpp
@@ -46,14 +46,16 @@ void find_all_gadget_from_ret(const std::vector<uint8_t> &memory,
       InstructionInformation instr =
           disass_engine.disass(EIP_, end_data - EIP_, VirtualAddr, ret);
 
-      const bool is_valid = g_opts.allow_branches ? true : !instr.is_branch;
+      const bool is_valid = g_opts.allow_branches || (!instr.is_branch);
       // if the instruction isn't valid, ends this function
       if (ret == UnknownInstruction || ret == OutOfBlock || !is_valid) {
         break;
       }
 
-      // Grab the bytes
-      instr.bytes.assign(EIP_, EIP_ + instr.size);
+      // Grab the bytes if we'll need to print them later
+      if (g_opts.print_bytes) {
+        instr.bytes.assign(EIP_, EIP_ + instr.size);
+      }
 
       // Sets the begining address of the gadget as soon as we find the first
       // one
@@ -126,8 +128,10 @@ void find_rop_gadgets(const std::vector<uint8_t> &section, const uint64_t vaddr,
       continue;
     }
 
-    // Grab the bytes
-    ret_instr.bytes.assign(data + offset, data + offset + ret_instr.size);
+    // Grab the bytes if we'll need to print them later
+    if (g_opts.print_bytes) {
+      ret_instr.bytes.assign(data + offset, data + offset + ret_instr.size);
+    }
 
     // Do not forget to add the ending instruction only -- we give to the user
     // all gadget with < depth instruction

--- a/src/rp/ropsearch_algorithm.cpp
+++ b/src/rp/ropsearch_algorithm.cpp
@@ -52,10 +52,8 @@ void find_all_gadget_from_ret(const std::vector<uint8_t> &memory,
         break;
       }
 
-      // Grab the bytes if we'll need to print them later
-      if (g_opts.print_bytes) {
-        instr.bytes.assign(EIP_, EIP_ + instr.size);
-      }
+      // Grab the bytes
+      instr.bytes.assign(EIP_, EIP_ + instr.size);
 
       // Sets the begining address of the gadget as soon as we find the first
       // one
@@ -128,10 +126,8 @@ void find_rop_gadgets(const std::vector<uint8_t> &section, const uint64_t vaddr,
       continue;
     }
 
-    // Grab the bytes if we'll need to print them later
-    if (g_opts.print_bytes) {
-      ret_instr.bytes.assign(data + offset, data + offset + ret_instr.size);
-    }
+    // Grab the bytes
+    ret_instr.bytes.assign(data + offset, data + offset + ret_instr.size);
 
     // Do not forget to add the ending instruction only -- we give to the user
     // all gadget with < depth instruction

--- a/src/rp/ropsearch_algorithm.cpp
+++ b/src/rp/ropsearch_algorithm.cpp
@@ -46,9 +46,7 @@ void find_all_gadget_from_ret(const std::vector<uint8_t> &memory,
       InstructionInformation instr =
           disass_engine.disass(EIP_, end_data - EIP_, VirtualAddr, ret);
 
-      const bool is_valid = g_opts.allow_branches
-                                ? true
-                                : disass_engine.is_valid_instruction(instr);
+      const bool is_valid = g_opts.allow_branches ? true : !instr.is_branch;
       // if the instruction isn't valid, ends this function
       if (ret == UnknownInstruction || ret == OutOfBlock || !is_valid) {
         break;
@@ -126,7 +124,7 @@ void find_rop_gadgets(const std::vector<uint8_t> &section, const uint64_t vaddr,
       continue;
     }
 
-    if (!disass_engine.is_valid_ending_instruction(ret_instr)) {
+    if (!ret_instr.is_valid_ending_instr) {
       continue;
     }
 


### PR DESCRIPTION
This PR removes the `BeaEngine` / `Capstone` specific field from the `InstructionInformation` structure and simplifies the `DisassEngineWrapper` interface as well (fixes #33).

It also fixes the `Gadget::Comparator` functor to operate on the dissassembly because since #41 they might not be there anymore.

Finally, it properly detects any kind of branches in a gadget - if `--allow-branches` is not specified, those will not appear as valid results.