### PR TITLE
Support build on arm64 hosts (Apple M1)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,11 +25,7 @@ elseif(UNIX)
     endif()
  endif()
 
-if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    set(RP_PLAT "rp-${RP_PLAT}-x64")
-else()
-    set(RP_PLAT "rp-${RP_PLAT}-x86")
-endif()
+set(RP_PLAT "rp-${RP_PLAT}-${CMAKE_HOST_SYSTEM_PROCESSOR}")
 
 file(
     GLOB

--- a/src/rp/main.cpp
+++ b/src/rp/main.cpp
@@ -13,8 +13,10 @@
 #define NUM_V "2.0"
 #ifdef ARCH_X64
 #define VERSION_TMP NUM_V " x64 built the " __DATE__ " " __TIME__
-#else
+#elif defined ARCH_X86
 #define VERSION_TMP NUM_V " x86 built the " __DATE__ " " __TIME__
+#else
+#define VERSION_TMP NUM_V " arm64 built the " __DATE__ " " __TIME__
 #endif
 
 #define VERSION_TM VERSION_TMP " for " SYSTEM_PLATFORM

--- a/src/rp/platform.h
+++ b/src/rp/platform.h
@@ -5,6 +5,8 @@
 #define ARCH_X86
 #elif defined(__amd64__) || defined(_M_X64)
 #define ARCH_X64
+#elif defined(__arm64__)
+#define ARCH_ARM64
 #else
 #error Platform not supported.
 #endif
@@ -37,6 +39,8 @@
 #define LINUX_X86
 #elif defined ARCH_X64
 #define LINUX_X64
+#elif defined ARCH_ARM64
+#define LINUX_ARM64
 #endif
 
 #else


### PR DESCRIPTION
- add `ARCH_ARM64` macro
- use `CMAKE_HOST_SYSTEM_PROCESSOR` to detect host architecture