### PR TITLE
Fix enumeration gadgets with unique option

### DIFF
--- a/src/rp/toolbox.cpp
+++ b/src/rp/toolbox.cpp
@@ -104,7 +104,7 @@ std::vector<uint8_t> string_to_hex(const std::string &hex) {
 GadgetSet only_unique_gadgets(GadgetMultiset &list_gadgets) {
   GadgetSet unique_gadgets;
   // Now we have a list of gadget, cool, but we want to keep only the unique!
-  for (size_t i = 0; i < list_gadgets.size(); i++) {
+  while (!list_gadgets.empty()) {
     auto node = list_gadgets.extract(list_gadgets.begin());
     const uint64_t first_offset = node.value().get_first_offset();
     const uint64_t first_va_section = node.value().get_first_va_section();


### PR DESCRIPTION
When rp++ is run with the `--unique` option, only half of all gadgets are used and the rest are ignored.

`list_gadgets.extract()` used in the for statement will remove the extracted element from the list_gadgets.
Therefore, `list_gadgets.size()` is decremented on each loop, and the for statement is only executed `list_gadgets.size()/2` times.

This PR fixes this issue.