### PR TITLE
Add __aarch64__ support

### DIFF
--- a/.github/workflows/rp.yml
+++ b/.github/workflows/rp.yml
@@ -73,8 +73,8 @@ jobs:
     - name: Build with clang
       if: matrix.compiler == 'clang'
       env:
-        CC: clang-15
-        CXX: clang++-15
+        CC: clang-16
+        CXX: clang++-16
       run: |
         cd src/build
         chmod u+x ./build-release.sh

--- a/.github/workflows/rp.yml
+++ b/.github/workflows/rp.yml
@@ -73,8 +73,8 @@ jobs:
     - name: Build with clang
       if: matrix.compiler == 'clang'
       env:
-        CC: clang-16
-        CXX: clang++-16
+        CC: clang-17
+        CXX: clang++-17
       run: |
         cd src/build
         chmod u+x ./build-release.sh

--- a/src/rp/platform.h
+++ b/src/rp/platform.h
@@ -5,7 +5,7 @@
 #define ARCH_X86
 #elif defined(__amd64__) || defined(_M_X64)
 #define ARCH_X64
-#elif defined(__arm64__)
+#elif defined(__arm64__) || defined(__aarch64__)
 #define ARCH_ARM64
 #else
 #error Platform not supported.


### PR DESCRIPTION
I am trying to run rp inside a Docker container on an arm64 host (Apple M1), but rp fails to build with the following error.
```
#6 9.803 /usr/bin/c++ -DBEA_ENGINE_STATIC -DCAPSTONE_HAS_ARM -DCAPSTONE_HAS_ARM64 -DCAPSTONE_USE_SYS_DYN_MEM -DFMT_HEADER_ONLY -I/rp/src/third_party/fmt/include -I/rp/src/third_party/beaengine/include -I/rp/src/third_party/capstone/include -I/rp/src/third_party/CLI11 -O3 -DNDEBUG -flto -fno-fat-lto-objects -std=gnu++20 -MD -MT CMakeFiles/rp-lin.dir/rp/program.cpp.o -MF CMakeFiles/rp-lin.dir/rp/program.cpp.o.d -o CMakeFiles/rp-lin.dir/rp/program.cpp.o -c /rp/src/rp/program.cpp
#6 9.803 In file included from /rp/src/rp/coloshell.hpp:4,
#6 9.803                  from /rp/src/rp/elf_struct.hpp:4,
#6 9.803                  from /rp/src/rp/elf.hpp:8,
#6 9.803                  from /rp/src/rp/program.hpp:8,
#6 9.803                  from /rp/src/rp/program.cpp:2:
#6 9.803 /rp/src/rp/platform.h:11:2: error: #error Platform not supported.
#6 9.803    11 | #error Platform not supported.
#6 9.803       |  ^~~~~
#6 10.08 [19/21] Building CXX object CMakeFiles/rp-lin.dir/rp/toolbox.cpp.o
#6 10.08 FAILED: CMakeFiles/rp-lin.dir/rp/toolbox.cpp.o 
#6 10.08 /usr/bin/c++ -DBEA_ENGINE_STATIC -DCAPSTONE_HAS_ARM -DCAPSTONE_HAS_ARM64 -DCAPSTONE_USE_SYS_DYN_MEM -DFMT_HEADER_ONLY -I/rp/src/third_party/fmt/include -I/rp/src/third_party/beaengine/include -I/rp/src/third_party/capstone/include -I/rp/src/third_party/CLI11 -O3 -DNDEBUG -flto -fno-fat-lto-objects -std=gnu++20 -MD -MT CMakeFiles/rp-lin.dir/rp/toolbox.cpp.o -MF CMakeFiles/rp-lin.dir/rp/toolbox.cpp.o.d -o CMakeFiles/rp-lin.dir/rp/toolbox.cpp.o -c /rp/src/rp/toolbox.cpp
#6 10.08 In file included from /rp/src/rp/coloshell.hpp:4,
#6 10.08                  from /rp/src/rp/elf_struct.hpp:4,
#6 10.08                  from /rp/src/rp/elf.hpp:8,
#6 10.08                  from /rp/src/rp/toolbox.cpp:3:
#6 10.08 /rp/src/rp/platform.h:11:2: error: #error Platform not supported.
#6 10.08    11 | #error Platform not supported.
#6 10.08       |  ^~~~~
#6 10.56 [20/21] Building CXX object CMakeFiles/rp-lin.dir/rp/main.cpp.o
#6 10.56 FAILED: CMakeFiles/rp-lin.dir/rp/main.cpp.o 
#6 10.56 /usr/bin/c++ -DBEA_ENGINE_STATIC -DCAPSTONE_HAS_ARM -DCAPSTONE_HAS_ARM64 -DCAPSTONE_USE_SYS_DYN_MEM -DFMT_HEADER_ONLY -I/rp/src/third_party/fmt/include -I/rp/src/third_party/beaengine/include -I/rp/src/third_party/capstone/include -I/rp/src/third_party/CLI11 -O3 -DNDEBUG -flto -fno-fat-lto-objects -std=gnu++20 -MD -MT CMakeFiles/rp-lin.dir/rp/main.cpp.o -MF CMakeFiles/rp-lin.dir/rp/main.cpp.o.d -o CMakeFiles/rp-lin.dir/rp/main.cpp.o -c /rp/src/rp/main.cpp
#6 10.56 In file included from /rp/src/rp/coloshell.hpp:4,
#6 10.56                  from /rp/src/rp/main.cpp:2:
#6 10.56 /rp/src/rp/platform.h:11:2: error: #error Platform not supported.
#6 10.56    11 | #error Platform not supported.
#6 10.56       |  ^~~~~
#6 10.56 ninja: build stopped: subcommand failed.
------
executor failed running [/bin/sh -c git clone https://github.com/0vercl0k/rp.git &&     cd rp &&     git checkout 7d8e61f &&     cd src/build &&     chmod u+x ./build-release.sh && ./build-release.sh]: exit code: 1
```

The Dockerfile for the test environment is below.
```Dockerfile
FROM ubuntu:22.04
ARG DEBIAN_FRONTEND=noninteractive

RUN apt-get update && \
    apt-get -y install --no-install-recommends \
	build-essential ca-certificates cmake git nano ninja-build && \
    rm -rf /var/lib/apt/lists/*

# Failed
RUN git clone https://github.com/0vercl0k/rp.git && \
    cd rp && \
    git checkout 7d8e61f && \
    cd src/build && \
    chmod u+x ./build-release.sh && ./build-release.sh
```

Operation on the arm64 host machine was supported by https://github.com/0vercl0k/rp/pull/44, but the result of the `uname -m` (`arch` is an alias) command is slightly different when the environment is different, and it seems that it does not work.

In this PR, I changed the code to treat it as ARM64 when the result of the `uname -m` command is `aarch64`. The test environment can be built successfully with the following Dockerfile.

```Dockerfile
FROM ubuntu:22.04
ARG DEBIAN_FRONTEND=noninteractive

RUN apt-get update && \
    apt-get -y install --no-install-recommends \
	build-essential ca-certificates cmake git nano ninja-build && \
    rm -rf /var/lib/apt/lists/*

# Successed
 RUN git clone https://github.com/mmxsrup/rp.git && \
     cd rp && \
     git checkout add-aarch64-support && \
     cd src/build && \
     chmod u+x ./build-release.sh && ./build-release.sh
```

For reference, when running the `uname -m` command inside a Docker container on an arm64 host (Apple M1), the result is as follows:
```
aarch64
```
