### PR TITLE
 Introduce sanitize_va() & has_prefix() for VA formatting

### DIFF
--- a/src/rp/main.cpp
+++ b/src/rp/main.cpp
@@ -30,8 +30,9 @@
 Options_t g_opts;
 
 int main(int argc, char *argv[]) {
-  CLI::App rp("rp++: a fast ROP gadget finder for pe/elf/mach-o x86/x64/ARM/ARM64 "
-              "binaries\nby Axel '0vercl0k' Souchet.\n");
+  CLI::App rp(
+      "rp++: a fast ROP gadget finder for pe/elf/mach-o x86/x64/ARM/ARM64 "
+      "binaries\nby Axel '0vercl0k' Souchet.\n");
   rp.add_option("-f,--file", g_opts.file, "Binary path")->required();
   rp.add_option("-i,--info", g_opts.display,
                 "display information about the binary header");
@@ -58,7 +59,7 @@ int main(int argc, char *argv[]) {
   rp.add_flag("--thumb", g_opts.thumb,
               "enable thumb mode when looking for ARM gadgets");
   rp.add_option("--va", g_opts.va,
-              "don't use the image base of the binary, but yours instead");
+                "don't use the image base of the binary, but yours instead");
   rp.add_flag("--allow-branches", g_opts.allow_branches,
               "allow branches in a gadget");
   rp.add_flag("--print-bytes", g_opts.print_bytes, "print the gadget bytes");
@@ -78,9 +79,8 @@ int main(int argc, char *argv[]) {
 
     // Here we set the base being 0 if we want to have absolute virtual
     // memory address displayed
-      const uint64_t base = g_opts.va.size() > 0
-                                ? std::strtoull((sanitize_va(g_opts.va)).c_str(), nullptr, 0)
-                                : p.get_image_base_address();
+    const uint64_t base = g_opts.va.size() > 0 ? va_to_integer(g_opts.va)
+                                               : p.get_image_base_address();
     if (g_opts.rop > 0) {
       const uint32_t options = g_opts.thumb ? 1 : 0;
       fmt::print("\nWait a few seconds, rp++ is looking for gadgets ({} "

--- a/src/rp/main.cpp
+++ b/src/rp/main.cpp
@@ -78,9 +78,9 @@ int main(int argc, char *argv[]) {
 
     // Here we set the base being 0 if we want to have absolute virtual
     // memory address displayed
-    const uint64_t base = g_opts.va.size() > 0
-                              ? std::strtoull(g_opts.va.c_str(), nullptr, 0)
-                              : p.get_image_base_address();
+      const uint64_t base = g_opts.va.size() > 0
+                                ? std::strtoull((sanitize_va(g_opts.va)).c_str(), nullptr, 0)
+                                : p.get_image_base_address();
     if (g_opts.rop > 0) {
       const uint32_t options = g_opts.thumb ? 1 : 0;
       fmt::print("\nWait a few seconds, rp++ is looking for gadgets ({} "

--- a/src/rp/toolbox.cpp
+++ b/src/rp/toolbox.cpp
@@ -41,13 +41,7 @@ std::streampos get_file_size(std::ifstream &file) {
   return fsize;
 }
 
-// Helper function to check if va has prefix (0x) or not
-bool has_prefix(const std::string &va) {
-  return va.size() > 2 && va[0] == '0' && (va[1] == 'x' || va[1] == 'X');
-}
-
 uint64_t va_to_integer(std::string va) {
-  __debugbreak();
   // Look for backticks; WinDbg splits a QWORD in two with one. We'll get rid of
   // it if we find one as this makes it easier to copy the address directly off
   // the debugger. It also means that if we find one, we'll assume the address
@@ -72,10 +66,10 @@ bool is_matching(const std::string &str, const std::string &pattern) {
     return false;
   }
 
-  size_t i = 0, maxLen = (std::min)(str.length(), pattern.length());
+  size_t i = 0, max = std::min(str.length(), pattern.length());
   bool it_matches = true;
 
-  while (i < maxLen) {
+  while (i < max) {
     if (pattern.at(i) != '?' && pattern.at(i) != str.at(i)) {
       it_matches = false;
       break;

--- a/src/rp/toolbox.cpp
+++ b/src/rp/toolbox.cpp
@@ -47,8 +47,7 @@ uint64_t va_to_integer(std::string va) {
   // the debugger. It also means that if we find one, we'll assume the address
   // is specified in base 16 so we'll force that.
   const auto it = std::remove(va.begin(), va.end(), '`');
-  const bool force_hex_prefix = it != va.end();
-  const int radix = force_hex_prefix ? 16 : 0;
+  const int radix = it != va.end() ? 16 : 0;
   // If `std::remove` returned a valid iterator, this is where we want
   // `strtoull` to stop; so let's terminate the string there.
   if (it != va.end()) {

--- a/src/rp/toolbox.cpp
+++ b/src/rp/toolbox.cpp
@@ -28,17 +28,42 @@ std::string verbosity_to_string(const VerbosityLevel lvl) {
   return "Unknwon";
 }
 
+// Get the size of an open file without changing its position
 std::streampos get_file_size(std::ifstream &file) {
+
+  // Save the current file ptr position
   std::streampos backup = file.tellg();
 
-  file.seekg(0, std::ios::beg);
+  // Move the ptr to the end
+  file.seekg(0, std::ios::end);
+
+  // Get the current file ptr position ( start = 0 + EOF )
   std::streampos fsize = file.tellg();
 
-  file.seekg(0, std::ios::end);
-  fsize = file.tellg() - fsize;
-
+  // Restore the previous ptr position
   file.seekg(backup);
+
   return fsize;
+}
+
+// Helper function to check if va has prefix (0x) or not
+bool has_prefix(const std::string &va) {
+  return va.size() > 2 && va[0] == '0' && (va[1] == 'x' || va[1] == 'X');
+}
+
+/* 
+* Sanitize VA copied from WinDbg (removes backticks)
+* Ensures "0x" prefix exists when needed
+*/
+std::string sanitize_va(std::string va) {
+
+  bool needs_prefix = !has_prefix(va);
+
+  // Remove backticks if present
+  va.erase(std::remove(va.begin(), va.end(), '`'), va.end());
+
+  return needs_prefix ? "0x" + va : va;
+
 }
 
 // this function is completely inspirated from the previous work of jonathan
@@ -49,10 +74,10 @@ bool is_matching(const std::string &str, const std::string &pattern) {
     return false;
   }
 
-  size_t i = 0, max = std::min(str.length(), pattern.length());
+  size_t i = 0, maxLen = (std::min)(str.length(), pattern.length());
   bool it_matches = true;
 
-  while (i < max) {
+  while (i < maxLen) {
     if (pattern.at(i) != '?' && pattern.at(i) != str.at(i)) {
       it_matches = false;
       break;

--- a/src/rp/toolbox.hpp
+++ b/src/rp/toolbox.hpp
@@ -26,6 +26,24 @@ enum VerbosityLevel {
 std::string verbosity_to_string(const VerbosityLevel lvl);
 
 /**
+ * @brief Checks if the given virtual address has a "0x" or "0X" prefix.
+ *
+ * @param va The virtual address string.
+ * @return true if the address has a "0x"/"0X" prefix, false otherwise.
+ */
+bool has_prefix(const std::string &va);
+
+/**
+ * @brief Sanitizes a virtual address copied from WinDbg.
+ *
+ * Removes backticks from the address and ensures it has a "0x" prefix if missing.
+ *
+ * @param va The virtual address string.
+ * @return A sanitized virtual address with proper formatting.
+ */
+std::string sanitize_va(std::string va);
+
+/**
  * \fn std::streampos get_file_size(std::ifstream &file)
  * \brief Get the size in byte of your file
  *
@@ -33,6 +51,7 @@ std::string verbosity_to_string(const VerbosityLevel lvl);
  *
  * \return the size in byte of the file
  */
+
 std::streampos get_file_size(std::ifstream &file);
 
 /**

--- a/src/rp/toolbox.hpp
+++ b/src/rp/toolbox.hpp
@@ -41,7 +41,6 @@ uint64_t va_to_integer(std::string va);
  *
  * \return the size in byte of the file
  */
-
 std::streampos get_file_size(std::ifstream &file);
 
 /**

--- a/src/rp/toolbox.hpp
+++ b/src/rp/toolbox.hpp
@@ -26,14 +26,14 @@ enum VerbosityLevel {
 std::string verbosity_to_string(const VerbosityLevel lvl);
 
 /**
- * \fn uint64_t va_to_hex(std::string &va)
+ * \fn uint64_t va_to_integer(std::string va)
  * \brief Convert va to an integer
  *
  * \param va The virtual address string
  */
 uint64_t va_to_integer(std::string va);
 
-  /**
+/**
  * \fn std::streampos get_file_size(std::ifstream &file)
  * \brief Get the size in byte of your file
  *

--- a/src/rp/toolbox.hpp
+++ b/src/rp/toolbox.hpp
@@ -26,24 +26,14 @@ enum VerbosityLevel {
 std::string verbosity_to_string(const VerbosityLevel lvl);
 
 /**
- * @brief Checks if the given virtual address has a "0x" or "0X" prefix.
+ * \fn uint64_t va_to_hex(std::string &va)
+ * \brief Convert va to an integer
  *
- * @param va The virtual address string.
- * @return true if the address has a "0x"/"0X" prefix, false otherwise.
+ * \param va The virtual address string
  */
-bool has_prefix(const std::string &va);
+uint64_t va_to_integer(std::string va);
 
-/**
- * @brief Sanitizes a virtual address copied from WinDbg.
- *
- * Removes backticks from the address and ensures it has a "0x" prefix if missing.
- *
- * @param va The virtual address string.
- * @return A sanitized virtual address with proper formatting.
- */
-std::string sanitize_va(std::string va);
-
-/**
+  /**
  * \fn std::streampos get_file_size(std::ifstream &file)
  * \brief Get the size in byte of your file
  *

--- a/src/third_party/capstone/MathExtras.h
+++ b/src/third_party/capstone/MathExtras.h
@@ -17,10 +17,12 @@
 #ifndef CS_LLVM_SUPPORT_MATHEXTRAS_H
 #define CS_LLVM_SUPPORT_MATHEXTRAS_H
 
+#if 0
 #if defined(_WIN32_WCE) && (_WIN32_WCE < 0x800)
 #include "windowsce/intrin.h"
 #elif defined(_MSC_VER)
 #include <intrin.h>
+#endif
 #endif
 
 #ifndef __cplusplus


### PR DESCRIPTION
**Summary**

This PR introduces two new utility functions, `sanitize_va()` and `has_prefix()`, to handle and properly format virtual addresses (VA), particularly when copied from WinDbg.

**Changes**
* **Added** `has_prefix()`
    
    * Checks if a virtual address string starts with `"0x"` or `"0X"`.
    * Also, prevents redundant prefixing in sanitization logic.

* **Added** `sanitize_va()`

    * Removes backticks ('\`') from VA strings (WinDbg formatting) ( Ex: ``00007ff7`89da0000`` )
    * Ensures `"0x"` prefix is added if missing.
    
* **Optimised** `get_file_size()`

    * Optimized to avoid unnecessary checks and modifications.
