### PR TITLE
Revert a fix to work around a bug in MSVC

### DIFF
--- a/src/third_party/capstone/MathExtras.h
+++ b/src/third_party/capstone/MathExtras.h
@@ -17,19 +17,10 @@
 #ifndef CS_LLVM_SUPPORT_MATHEXTRAS_H
 #define CS_LLVM_SUPPORT_MATHEXTRAS_H
 
-// XXX: On Windows MSVC 19.43.34808 I get those and I don't know how to fix that (other than disabling the below macros):
-// ```
-// 2>AArch64InstPrinter.obj : warning LNK4006: _get_vlen already defined in AArch64Disassembler.obj; second definition ignored
-// 2>AArch64InstPrinter.obj : warning LNK4006: __check_arch_support already defined in AArch64Disassembler.obj; second definition ignored
-// 2>AArch64InstPrinter.obj : warning LNK4006: __check_isa_avx10_512 already defined in AArch64Disassembler.obj; second definition ignored
-// 2>AArch64InstPrinter.obj : warning LNK4006: __check_isa_support already defined in AArch64Disassembler.obj; second definition ignored
-// ```
-#if 0
 #if defined(_WIN32_WCE) && (_WIN32_WCE < 0x800)
 #include "windowsce/intrin.h"
 #elif defined(_MSC_VER)
 #include <intrin.h>
-#endif
 #endif
 
 #ifndef __cplusplus

--- a/src/third_party/capstone/MathExtras.h
+++ b/src/third_party/capstone/MathExtras.h
@@ -29,7 +29,6 @@
 #endif
 #endif
 
-
 // NOTE: The following support functions use the _32/_64 extensions instead of
 // type overloading so that signed and unsigned integers can be used without
 // ambiguity.

--- a/src/third_party/capstone/MathExtras.h
+++ b/src/third_party/capstone/MathExtras.h
@@ -29,6 +29,7 @@
 #endif
 #endif
 
+
 // NOTE: The following support functions use the _32/_64 extensions instead of
 // type overloading so that signed and unsigned integers can be used without
 // ambiguity.


### PR DESCRIPTION
Those were the linking errors that the work around was side-stepping in the previous MSVC version:
```
2>AArch64InstPrinter.obj : warning LNK4006: _get_vlen already defined in AArch64Disassembler.obj; second definition ignored
2>AArch64InstPrinter.obj : warning LNK4006: __check_arch_support already defined in AArch64Disassembler.obj; second definition ignored
2>AArch64InstPrinter.obj : warning LNK4006: __check_isa_avx10_512 already defined in AArch64Disassembler.obj; second definition ignored
2>AArch64InstPrinter.obj : warning LNK4006: __check_isa_support already defined in AArch64Disassembler.obj; second definition ignored
```

It was fixed by https://developercommunity.visualstudio.com/t/_get_vlen--__check_arch_support--__che/10850517.